### PR TITLE
Restore setting of sensors interface.

### DIFF
--- a/src/plugins/sensors/sensorfw/sensorfwsensorbase.h
+++ b/src/plugins/sensors/sensorfw/sensorfwsensorbase.h
@@ -90,6 +90,10 @@ protected:
             }
             m_remoteSensorManager->registerSensorInterface<T>(name);
         }
+        m_sensorInterface = T::controlInterface(name);
+        if (!m_sensorInterface) {
+            m_sensorInterface = const_cast<T*>(T::listenInterface(name));
+        }
         initDone = initSensorInterface(name);
     };
 


### PR DESCRIPTION
Change I5c1bf3999ad2268c0dba9b3fe511d999c2e63fd9's forward porting from Qt 5.1
removed this, thus the interface was never set, thus sensors all broke.

Change-Id: If3b14b5ebd20e6cb64bc2000b23a2c1e37d36b05
Reviewed-by: Alex Blasche alexander.blasche@digia.com
